### PR TITLE
Correct matching of readme navigation entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Correct matching of readme navigation entry ([#23](https://github.com/scm-manager/scm-readme-plugin/pull/23))
+
 ## 2.0.0 - 2020-06-04
 ### Fixed
 - Fixed usage of relative links in readme ([#5](https://github.com/scm-manager/scm-readme-plugin/pull/5))

--- a/src/main/js/index.tsx
+++ b/src/main/js/index.tsx
@@ -33,7 +33,7 @@ const predicate = (props: any) => {
 };
 
 function matches(route: any) {
-  const regex = new RegExp(".*(/readme)");
+  const regex = new RegExp(".*(/readme)$");
   return route.location.pathname.match(regex);
 }
 


### PR DESCRIPTION
## Proposed changes

Whenever a repository or namespace contained "readme", the readme entry is shown active in the navigation.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
