### PR TITLE
Skip directories when searching for readme file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,16 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.1'
+  id 'org.scm-manager.smp' version '0.10.3'
 }
 
 dependencies {
+  testImplementation "org.junit.vintage:junit-vintage-engine:5.7.0"
+  testImplementation 'junit:junit:4.13.1'
 }
 
 scmPlugin {
-  scmVersion = "2.0.0"
+  scmVersion = "2.0.0" // TODO: remove junit dependencies above when updating to a newer core version
   displayName = "Readme"
   description = "Shows the Readme content of a repository"
   author = "Cloudogu GmbH"

--- a/gradle/changelog/ignore_directories.yaml
+++ b/gradle/changelog/ignore_directories.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Skip directories matching readme filename pattern ([#29](https://github.com/scm-manager/scm-readme-plugin/pull/29))

--- a/src/main/java/com/cloudogu/scm/readme/ReadmeManager.java
+++ b/src/main/java/com/cloudogu/scm/readme/ReadmeManager.java
@@ -119,6 +119,7 @@ public class ReadmeManager {
       .map(BrowserResult::getFile)
       .flatMap(fo -> fo.getChildren()
         .stream()
+        .filter(fileObject -> !fileObject.isDirectory())
         .map(FileObject::getName)
         .filter(fileName -> README_FILES.contains(fileName.toLowerCase()))
         .findFirst());

--- a/src/test/java/com/cloudogu/scm/readme/ReadmeManagerTest.java
+++ b/src/test/java/com/cloudogu/scm/readme/ReadmeManagerTest.java
@@ -158,6 +158,17 @@ public class ReadmeManagerTest {
 
   @Test
   @SubjectAware(username = "trillian", password = "secret")
+  public void shouldIgnoreDirectory() throws IOException {
+    String readmeDirectory = "readme";
+    FileObject directory = createReadme(readmeDirectory);
+    directory.setDirectory(true);
+
+    Optional<Readme> readme = readmeManager.getReadme(NAMESPACE, NAME);
+    assertThat(readme).isNotPresent();
+  }
+
+  @Test
+  @SubjectAware(username = "trillian", password = "secret")
   public void shouldReturnEmptyObjectWithoutRevision() throws IOException {
     String readmeFile = "ReadMe.md";
     createReadme(readmeFile);
@@ -203,19 +214,20 @@ public class ReadmeManagerTest {
     return event;
   }
 
-  private void createReadme(String name) throws IOException {
+  private FileObject createReadme(String name) throws IOException {
     when(serviceFactory.create(any(NamespaceAndName.class))).thenReturn(service);
     createRepository();
     FileObject file = new FileObject();
     file.setPath("/");
     file.setDirectory(true);
-    FileObject childFile1 = new FileObject();
-    childFile1.setName(name);
-    List<FileObject> children = Lists.newArrayList(childFile1);
+    FileObject childFile = new FileObject();
+    childFile.setName(name);
+    List<FileObject> children = Lists.newArrayList(childFile);
     file.setChildren(children);
     BrowserResult br = new BrowserResult("rev", file);
     when(builder.getBrowserResult()).thenReturn(br);
     when(catCommand.getContent(name)).thenReturn(CONTENT_OF_THE_README_FILE);
+    return childFile;
   }
 
   private void createRepository() {


### PR DESCRIPTION
## Proposed changes

Fixes a bug when a repository contains a directory called, for example, `readme`. This led to a "Not Found" error, because the frontend tried to load the directory as a file.

Reported via [mycloudogu](https://community.cloudogu.com/t/readme-error-when-readme-folder-exists-besides-readme-md/440/)

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
